### PR TITLE
Add prepare-root.conf

### DIFF
--- a/rootfs/usr/lib/ostree/prepare-root.conf
+++ b/rootfs/usr/lib/ostree/prepare-root.conf
@@ -1,0 +1,2 @@
+[composefs]
+enabled = yes


### PR DESCRIPTION
This is needed for `bootc install to-filesystem`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option to enable the "composefs" feature during system preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->