### PR TITLE
Add ups udev rule

### DIFF
--- a/rootfs/usr/etc/udev/rules.d/ups.rules
+++ b/rootfs/usr/etc/udev/rules.d/ups.rules
@@ -1,2 +1,2 @@
 # EF-UPS-DELTA 
-SUBSYSTEM=="usb", ATTRS{idVendor}=="3746", ATTRS{idProduct}=="ffff", MODE="0666", SYMLINK+="ups"
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="3746", ATTRS{idProduct}=="ffff", MODE="0666", SYMLINK+="ups"

--- a/rootfs/usr/etc/udev/rules.d/ups.rules
+++ b/rootfs/usr/etc/udev/rules.d/ups.rules
@@ -1,0 +1,2 @@
+# EF-UPS-DELTA 
+SUBSYSTEM=="usb", ATTRS{idVendor}=="3746", ATTRS{idProduct}=="ffff", MODE="0666", SYMLINK+="ups"


### PR DESCRIPTION
Fixes #9 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for automatic detection and setup of specific USB UPS devices, ensuring they are accessible to all users and easily identifiable via a symbolic link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->