### PR TITLE
Allow Flightctl access to SSSD config

### DIFF
--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -52,6 +52,12 @@ jobs:
             type=semver,pattern=v{{major}}.{{minor}}
             type=semver,pattern=v{{major}}.{{minor}}.{{patch}}
 
+      - name: Build SELinux files
+        run: |
+          apt install -y make
+          cd selinux
+          make all
+
       - name: Buildah Build
         id: build-image
         uses: redhat-actions/buildah-build@v2

--- a/Containerfile
+++ b/Containerfile
@@ -34,6 +34,9 @@ RUN dnf install -y authselect chrony oddjobd oddjob-mkhomedir sssd-idp  && \
 # Don't reboot unexpectedly
 RUN rm -f /usr/lib/systemd/system/default.target.wants/bootc-fetch-apply-updates.timer
 
+RUN --mount=source=/selinux,target=/selinux \
+    for module in $(ls /selinux/*.pp); do semodule -i ${module}; done
+
 # Cleanup
 RUN rm -Rf /var/log/dnf5* \
            /var/cache/libdnf5 \

--- a/selinux/Makefile
+++ b/selinux/Makefile
@@ -1,0 +1,16 @@
+TE_FILES  := $(wildcard *.te)
+MOD_FILES := $(TE_FILES:.te=.mod)
+PP_FILES  := $(TE_FILES:.te=.pp)
+
+all: $(PP_FILES)
+
+%.mod: %.te
+    checkmodule -M -m -o $@ $<
+
+%.pp: %.mod
+    semodule_package -o $@ -m $<
+
+clean:
+    rm -f $(MOD_FILES) $(PP_FILES)
+
+.PHONY: all clean

--- a/selinux/flightctl_sssd_rw.te
+++ b/selinux/flightctl_sssd_rw.te
@@ -1,0 +1,10 @@
+module flightctl_sssd_rw 1.0;
+
+require {
+    type flightctl_agent_t;
+    type sssd_conf_t;
+    class file { read write open getattr };
+}
+
+# Grant full read/write access
+allow flightctl_agent_t sssd_conf_t:file { read write open getattr };


### PR DESCRIPTION
SELinux is preventing Flightctl from accessing the SSSD config. This adds the SELinux policy file