### PR TITLE
Ensure NetworkManager connection permissions are set correctly

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -32,7 +32,7 @@ RUN dnf install -y cloud-init tmux which rsync && \
 RUN systemctl enable nftables.service \
                      protect_etc.service \
                      pull_images.path \
-                     fix_perms_nm.path
+                     fix_perms_nm.path \
                      cloud-init.target
 
 # Install packages for OIDC authentication

--- a/Containerfile
+++ b/Containerfile
@@ -53,7 +53,7 @@ RUN rm -f /usr/lib/systemd/system/default.target.wants/bootc-fetch-apply-updates
 
 RUN --mount=from=selinux,source=/selinux-pp,target=/selinux \
     if ls /selinux/*.pp 1> /dev/null 2>&1; then \
-      for module in /selinux/*.pp; do semodule -i "${module}"; done; \
+      for module in /selinux/*.pp; do semodule -vi "${module}"; done; \
     fi
 
 # Cleanup

--- a/Containerfile
+++ b/Containerfile
@@ -32,6 +32,7 @@ RUN dnf install -y cloud-init tmux which rsync && \
 RUN systemctl enable nftables.service \
                      protect_etc.service \
                      pull_images.path \
+                     fix_perms_nm.path
                      cloud-init.target
 
 # Install packages for OIDC authentication

--- a/rootfs/etc/nftables/main.nft
+++ b/rootfs/etc/nftables/main.nft
@@ -33,4 +33,4 @@ table inet nftables {
 # As long as the same table and chain names are used, the only traffic left will be new packets
 # Files are loaded in alphabetical order
 
-include /etc/nftables/local.nft.d/
+include "/etc/nftables/local.nft.d/"

--- a/rootfs/etc/systemd/system/fix_perms_nm.path
+++ b/rootfs/etc/systemd/system/fix_perms_nm.path
@@ -1,0 +1,8 @@
+[Unit]
+Description=Watches for changes to nmconnections
+
+[Path]
+PathChanged=/etc/NetworkManager/system-connections
+
+[Install]
+WantedBy=multi-user.target

--- a/rootfs/etc/systemd/system/fix_perms_nm.service
+++ b/rootfs/etc/systemd/system/fix_perms_nm.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Fixes nmconnection permssions
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -c "chmod go= /etc/NetworkManager/system-connections/*"

--- a/rootfs/etc/systemd/system/fix_perms_nm.service
+++ b/rootfs/etc/systemd/system/fix_perms_nm.service
@@ -3,4 +3,4 @@ Description=Fixes nmconnection permssions
 
 [Service]
 Type=oneshot
-ExecStart=/bin/bash -c "chmod go= /etc/NetworkManager/system-connections/*"
+ExecStart=/usr/bin/find /etc/NetworkManager/system-connections -type f -exec chmod go= {} +


### PR DESCRIPTION
Flightctl configures git files with 644 permissions and then reloads NetworkManager. This results in all network connections being dropped due to file permissions. This path and service will reset the file permissions to the right values as soon as the files are changed, which should be faster than Flightctl can trigger a reload of NetworkManager.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new system service that automatically fixes permissions for NetworkManager connection files upon changes.
* **Improvements**
  * Enhanced SELinux policy installation with verbose output for better transparency.
  * Updated nftables configuration syntax by adding quotes to the include directive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->