### PR TITLE
Ensure watchdog is enabled

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -25,7 +25,7 @@ RUN dnf install -y dnf5-plugins && \
 COPY rootfs/ /
 
 # Install useful packages
-RUN dnf install -y cloud-init tmux which rsync watchdog && \
+RUN dnf install -y cloud-init tmux which rsync && \
     dnf clean all
 
 # Enable services
@@ -33,14 +33,7 @@ RUN systemctl enable nftables.service \
                      protect_etc.service \
                      pull_images.path \
                      fix_perms_nm.path \
-                     cloud-init.target \
-                     watchdog.service
-
-# Enable watchdog device
-RUN sed -i 's/#watchdog-device/watchdog-device/' /etc/watchdog.conf
-
-# Debug 
-RUN cat /etc/watchdog.conf
+                     cloud-init.target
 
 # Install packages for OIDC authentication
 RUN dnf install -y authselect \

--- a/rootfs/etc/systemd/system.conf.d/watchdog.conf
+++ b/rootfs/etc/systemd/system.conf.d/watchdog.conf
@@ -1,0 +1,2 @@
+[Manager]
+RuntimeWatchdogSec=default


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a system-level configuration to systemd, setting RuntimeWatchdogSec to default. This standardizes watchdog behavior across environments, reducing variance from custom settings. Users should see no functional change, but systems may exhibit improved stability and compatibility with hardware watchdogs and virtualization platforms. No UI or workflow changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->