### PR TITLE
Use Armbian kernel for rk3328

### DIFF
--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -117,6 +117,67 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
+  build-rockchip:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-24.04-arm
+        include:
+          - os: ubuntu-24.04-arm
+            arch: arm64
+    name: Build Rockchip Container Image
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+          fetch-depth: 0
+          fetch-tags: 'true'
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          flavor: |
+            suffix=-${{ matrix.arch }}
+          images: |
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}.{{minor}}.{{patch}}
+
+      - name: Buildah Build
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          containerfiles: Containerfile.rk3328
+          tags: ${{ steps.meta.outputs.tags || steps.meta_pr.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels || steps.meta_pr.outputs.labels }}
+
+      - name: Push image
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Trigger other builds
+        if: github.ref_name == github.event.repository.default_branch
+        env:
+          repo_owner: ${{ github.repository_owner }}
+          token: ${{ secrets.TRIGGER_PAT }}
+        run: |
+          chmod +x scripts/trigger_builds/trigger_builds.sh
+          ./scripts/trigger_builds/trigger_builds.sh
+
   make-raw:
     name: Create Raw Image
     strategy:

--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -156,7 +156,7 @@ jobs:
       - name: Download and extract kernel
         run: |
           sudo apt update
-          sudo apt install -y xz jq curl dpkg fdisk
+          sudo apt install -y xz-utils jq curl dpkg fdisk
           IMAGE_NAME=$(curl -s https://armbian.hosthatch.com/dl/renegade/archive/ \
             | grep -o 'Armbian_[^"]*_minimal.img.xz' \
             | sort -V \

--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -143,7 +143,7 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           flavor: |
-            suffix=-${{ matrix.arch }}
+            suffix=-${{ matrix.arch }}-rk3328
           images: |
             ghcr.io/${{ github.repository }}
           tags: |
@@ -152,6 +152,21 @@ jobs:
             type=semver,pattern=v{{version}}
             type=semver,pattern=v{{major}}.{{minor}}
             type=semver,pattern=v{{major}}.{{minor}}.{{patch}}
+
+      - name: Download and extract kernel
+        run: |
+          sudo apt update
+          sudo apt install -y xz jq curl dpkg fdisk
+          IMAGE_NAME=$(curl -s https://armbian.hosthatch.com/dl/renegade/archive/ \
+            | grep -o 'Armbian_[^"]*_minimal.img.xz' \
+            | sort -V \
+            | tail -n 1)
+          curl -L -o armbian.img.xz "https://armbian.hosthatch.com/dl/renegade/archive/${IMAGE_NAME}"
+          unxz armbian.img.xz
+          SECTOR_START=$(fdisk -l armbian.img | awk '/img1/ {print $2}')
+          OFFSET=$((SECTOR_START * 512))
+          mkdir -p armbian_mnt
+          sudo mount -o loop,offset=$OFFSET armbian.img armbian_mnt
 
       - name: Buildah Build
         id: build-image
@@ -168,15 +183,6 @@ jobs:
           tags: ${{ steps.build-image.outputs.tags }}
           username: ${{ github.actor }}
           password: ${{ github.token }}
-
-      - name: Trigger other builds
-        if: github.ref_name == github.event.repository.default_branch
-        env:
-          repo_owner: ${{ github.repository_owner }}
-          token: ${{ secrets.TRIGGER_PAT }}
-        run: |
-          chmod +x scripts/trigger_builds/trigger_builds.sh
-          ./scripts/trigger_builds/trigger_builds.sh
 
   make-raw:
     name: Create Raw Image

--- a/Containerfile.rk3328
+++ b/Containerfile.rk3328
@@ -1,6 +1,6 @@
 FROM quay.io/fedora/fedora:latest AS armbian_kernel
 
-RUN dnf install -y xz jq curl dpkg
+RUN dnf install -y xz jq curl dpkg fdisk
 
 WORKDIR /tmp/armbian
 

--- a/Containerfile.rk3328
+++ b/Containerfile.rk3328
@@ -1,30 +1,13 @@
 FROM quay.io/fedora/fedora:latest AS armbian_kernel
 
-RUN dnf install -y xz jq curl dpkg fdisk
-
 WORKDIR /tmp/armbian
 
-# Fetch directory listing and pick the newest minimal image
-RUN curl -s https://armbian.hosthatch.com/dl/renegade/archive/ \
-    | grep -o 'Armbian_[^"]*_minimal.img.xz' \
-    | sort -V \
-    | tail -n 1 \
-    > image_name
-
-# Download the image
-RUN curl -L -o armbian.img.xz "https://armbian.hosthatch.com/dl/renegade/archive/$(cat image_name)" && \
-    unxz armbian.img.xz
-
 # Extract the image
-RUN SECTOR_START=$(fdisk -l armbian.img | awk '/img1/ {print $2}') && \
-    OFFSET=$((SECTOR_START * 512)) && \
-    mkdir mnt && \
-    mount -o loop,offset=$OFFSET armbian.img mnt && \
-    cp -rv mnt/lib/modules                    /tmp/armbian/modules                                    && \
-    cp -rv mnt/boot/vmlinuz-*                 /tmp/armbian/modules/$(ls /tmp/armbian/modules)/vmlinuz && \
-    cp -rv mnt/boot/initrd.img-*              /tmp/armbian/modules/$(ls /tmp/armbian/modules)/initrd  && \
-    cp -rv mnt/usr/lib/linux-image-*/rockchip /tmp/armbian/modules/$(ls /tmp/armbian/modules)/dtb/    && \
-    umount mnt
+RUN --mount=type=bind,source=armbian_mnt,dst=/mnt \
+    cp -rv /mnt/lib/modules                    /tmp/armbian/modules                                    && \
+    cp -rv /mnt/boot/vmlinuz-*                 /tmp/armbian/modules/$(ls /tmp/armbian/modules)/vmlinuz && \
+    cp -rv /mnt/boot/initrd.img-*              /tmp/armbian/modules/$(ls /tmp/armbian/modules)/initrd  && \
+    cp -rv /mnt/usr/lib/linux-image-*/rockchip /tmp/armbian/modules/$(ls /tmp/armbian/modules)/dtb/
 
 FROM ghcr.io/jasonn3/fedora_base:main
 

--- a/Containerfile.rk3328
+++ b/Containerfile.rk3328
@@ -1,0 +1,36 @@
+FROM quay.io/fedora/fedora:latest AS armbian_kernel
+
+RUN dnf install -y xz jq curl dpkg
+
+WORKDIR /tmp/armbian
+
+# Fetch directory listing and pick the newest minimal image
+RUN curl -s https://armbian.hosthatch.com/dl/renegade/archive/ \
+    | grep -o 'Armbian_[^"]*_minimal.img.xz' \
+    | sort -V \
+    | tail -n 1 \
+    > image_name
+
+# Download the image
+RUN curl -L -o armbian.img.xz "https://armbian.hosthatch.com/dl/renegade/archive/$(cat image_name)"
+
+# Extract the image
+RUN SECTOR_START=$(fdisk -l armbian.img | awk '/img1/ {print $2}') && \
+    OFFSET=$((SECTOR_START * 512)) && \
+    mkdir mnt && \
+    mount -o loop,offset=$OFFSET armbian.img mnt && \
+    cp -r mnt/boot /tmp/armbian/boot && \
+    cp -r mnt/usr/lib/linux-image-* /tmp/armbian/linux-image && \
+    cp -r mnt/lib/modules /tmp/armbian/modules && \
+    umount mnt
+
+FROM ghcr.io/jasonn3/fedora_base:main
+
+# Install kernel, initrd, dtbs, modules
+COPY --from=armbian_kernel /tmp/armbian/boot/vmlinuz-*       /boot/
+COPY --from=armbian_kernel /tmp/armbian/boot/initrd.img-*    /boot/
+COPY --from=armbian_kernel /tmp/armbian/linux-image/rockchip /boot/dtb/
+COPY --from=armbian_kernel /tmp/armbian/modules/*            /lib/modules/
+
+# Provide bootloader entry
+COPY --from=armbian_kernel extlinux.conf /boot/extlinux/extlinux.conf

--- a/Containerfile.rk3328
+++ b/Containerfile.rk3328
@@ -13,7 +13,7 @@ RUN curl -s https://armbian.hosthatch.com/dl/renegade/archive/ \
 
 # Download the image
 RUN curl -L -o armbian.img.xz "https://armbian.hosthatch.com/dl/renegade/archive/$(cat image_name)" && \
-    unxz armbian.img
+    unxz armbian.img.xz
 
 # Extract the image
 RUN SECTOR_START=$(fdisk -l armbian.img | awk '/img1/ {print $2}') && \

--- a/Containerfile.rk3328
+++ b/Containerfile.rk3328
@@ -12,25 +12,24 @@ RUN curl -s https://armbian.hosthatch.com/dl/renegade/archive/ \
     > image_name
 
 # Download the image
-RUN curl -L -o armbian.img.xz "https://armbian.hosthatch.com/dl/renegade/archive/$(cat image_name)"
+RUN curl -L -o armbian.img.xz "https://armbian.hosthatch.com/dl/renegade/archive/$(cat image_name)" && \
+    unxz armbian.img
 
 # Extract the image
 RUN SECTOR_START=$(fdisk -l armbian.img | awk '/img1/ {print $2}') && \
     OFFSET=$((SECTOR_START * 512)) && \
     mkdir mnt && \
     mount -o loop,offset=$OFFSET armbian.img mnt && \
-    cp -r mnt/boot /tmp/armbian/boot && \
-    cp -r mnt/usr/lib/linux-image-* /tmp/armbian/linux-image && \
-    cp -r mnt/lib/modules /tmp/armbian/modules && \
+    cp -rv mnt/lib/modules                    /tmp/armbian/modules                                    && \
+    cp -rv mnt/boot/vmlinuz-*                 /tmp/armbian/modules/$(ls /tmp/armbian/modules)/vmlinuz && \
+    cp -rv mnt/boot/initrd.img-*              /tmp/armbian/modules/$(ls /tmp/armbian/modules)/initrd  && \
+    cp -rv mnt/usr/lib/linux-image-*/rockchip /tmp/armbian/modules/$(ls /tmp/armbian/modules)/dtb/    && \
     umount mnt
 
 FROM ghcr.io/jasonn3/fedora_base:main
 
-# Install kernel, initrd, dtbs, modules
-COPY --from=armbian_kernel /tmp/armbian/boot/vmlinuz-*       /boot/
-COPY --from=armbian_kernel /tmp/armbian/boot/initrd.img-*    /boot/
-COPY --from=armbian_kernel /tmp/armbian/linux-image/rockchip /boot/dtb/
-COPY --from=armbian_kernel /tmp/armbian/modules/*            /lib/modules/
+# Remove original kernel
+RUN rm -Rf /usr/lib/modules/*
 
-# Provide bootloader entry
-COPY --from=armbian_kernel extlinux.conf /boot/extlinux/extlinux.conf
+# Add copied data
+COPY --from=armbian_kernel /tmp/armbian/modules/*            /usr/lib/modules/


### PR DESCRIPTION
Armbian has some fixes to the NIC driver that are not in the mainline kernel. This will build an image that combines the kernel from Armbian with the userland from Fedora

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added official support for Rockchip RK3328 (ARM64) with container images that include matching kernel modules, kernel/initramfs images, and device-tree binaries for improved compatibility and performance on RK3328 devices.
  * Introduced automated ARM64 image build-and-publish workflow so RK3328 images are produced and released alongside existing multi-arch images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->