### PR TITLE
Install gem version if package is unavailable

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -20,8 +20,10 @@ RUN --mount=type=tmpfs,target=/run \
     ( ( dnf install -y https://yum.voxpupuli.org/openvox8-release-fedora-${VERSION_ID}.noarch.rpm && \
         dnf install -y openvox-agent \
       ) || \
-      ( dnf install -y rubygems rubygem-{scanf,racc,hocon,thor,locale,deep_merge,concurrent-ruby} && \
-        gem install openvox \
+      ( dnf remove -y openvox8-release-fedora 2>/dev/null || true && \
+        dnf install -y rubygems rubygem-{scanf,racc,hocon,thor,locale,deep_merge,concurrent-ruby} && \
+        gem install openvox && \
+        ln -s /usr/local/share/gems/gems/openvox-*/ext/systemd/puppet.service /usr/lib/systemd/system/puppet.service
     ) ) && \
     dnf install -y podman podman-compose && \
     dnf clean all && \

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-ARG FEDORA_BOOTC_VERSION=43
+ARG FEDORA_BOOTC_VERSION=44
 
 FROM quay.io/fedora/fedora-bootc:${FEDORA_BOOTC_VERSION} as selinux
 
@@ -17,8 +17,13 @@ FROM quay.io/fedora/fedora-bootc:${FEDORA_BOOTC_VERSION}
 # Install and enable openvox
 RUN --mount=type=tmpfs,target=/run \
     source /etc/os-release && \
-    dnf install -y https://yum.voxpupuli.org/openvox8-release-fedora-${VERSION_ID}.noarch.rpm && \
-    dnf install -y openvox-agent podman podman-compose && \
+    ( ( dnf install -y https://yum.voxpupuli.org/openvox8-release-fedora-${VERSION_ID}.noarch.rpm && \
+        dnf install -y openvox-agent \
+      ) || \
+      ( dnf install -y rubygems rubygem-{scanf,racc,hocon,thor,locale,deep_merge,concurrent-ruby} && \
+        gem install openvox \
+    ) ) && \
+    dnf install -y podman podman-compose && \
     dnf clean all && \
     systemctl enable puppet.service
 

--- a/Containerfile
+++ b/Containerfile
@@ -20,7 +20,7 @@ RUN --mount=type=tmpfs,target=/run \
     ( ( dnf install -y https://yum.voxpupuli.org/openvox8-release-fedora-${VERSION_ID}.noarch.rpm && \
         dnf install -y openvox-agent \
       ) || \
-      ( dnf remove -y openvox8-release-fedora 2>/dev/null || true && \
+      ( dnf remove -y openvox8-release-fedora; \
         dnf install -y rubygems rubygem-{scanf,racc,hocon,thor,locale,deep_merge,concurrent-ruby} && \
         gem install openvox && \
         ln -s /usr/local/share/gems/gems/openvox-*/ext/systemd/puppet.service /usr/lib/systemd/system/puppet.service && \

--- a/Containerfile
+++ b/Containerfile
@@ -23,7 +23,7 @@ RUN --mount=type=tmpfs,target=/run \
       ( dnf remove -y openvox8-release-fedora 2>/dev/null || true && \
         dnf install -y rubygems rubygem-{scanf,racc,hocon,thor,locale,deep_merge,concurrent-ruby} && \
         gem install openvox && \
-        ln -s /usr/local/share/gems/gems/openvox-*/ext/systemd/puppet.service /usr/lib/systemd/system/puppet.service
+        ln -s /usr/local/share/gems/gems/openvox-*/ext/systemd/puppet.service /usr/lib/systemd/system/puppet.service && \
     ) ) && \
     dnf install -y podman podman-compose && \
     dnf clean all && \

--- a/Containerfile
+++ b/Containerfile
@@ -23,7 +23,7 @@ RUN --mount=type=tmpfs,target=/run \
       ( dnf remove -y openvox8-release-fedora; \
         dnf install -y rubygems rubygem-{scanf,racc,hocon,thor,locale,deep_merge,concurrent-ruby} && \
         gem install openvox && \
-        ln -s /usr/local/share/gems/gems/openvox-*/ext/systemd/puppet.service /usr/lib/systemd/system/puppet.service && \
+        ln -s /usr/local/share/gems/gems/openvox-*/ext/systemd/puppet.service /usr/lib/systemd/system/puppet.service \
     ) ) && \
     dnf install -y podman podman-compose && \
     dnf clean all && \

--- a/Containerfile
+++ b/Containerfile
@@ -20,7 +20,7 @@ RUN --mount=type=tmpfs,target=/run \
     ( ( dnf install -y https://yum.voxpupuli.org/openvox8-release-fedora-${VERSION_ID}.noarch.rpm && \
         dnf install -y openvox-agent \
       ) || \
-      ( dnf remove -y openvox8-release-fedora; \
+      ( dnf remove -y openvox8-release; \
         dnf install -y rubygems rubygem-{scanf,racc,hocon,thor,locale,deep_merge,concurrent-ruby} && \
         gem install openvox && \
         ln -s /usr/local/share/gems/gems/openvox-*/ext/systemd/puppet.service /usr/lib/systemd/system/puppet.service \


### PR DESCRIPTION
OpenVox is currently lagging behind OS releases. Installing the gem when the package is unavailable fills the gap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the base container image to Fedora 44 for access to the latest platform features and security updates.
  * Enhanced OpenVox component installation with a robust fallback flow for greater reliability across environments.
  * Added container tooling (podman and podman-compose) into the build to support container operations within the environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->